### PR TITLE
remove minimumplayers dos UIV

### DIFF
--- a/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
+++ b/Resources/Prototypes/_NF/Events/nf_bluespace_grids_events.yml
@@ -141,7 +141,7 @@
     endAudio:
       path: /Audio/_NF/Announcements/PocketSizedAndy/andy2_bluespace_ship_leave.ogg
     earliestStart: 80
-    minimumPlayers: 15
+    # minimumPlayers: 15 - Andromeda
     weight: 1
     duration: 1800
     maxDuration: 2400
@@ -180,7 +180,7 @@
     endAudio:
       path: /Audio/_NF/Announcements/PocketSizedAndy/andy2_bluespace_ship_leave.ogg
     earliestStart: 100
-    minimumPlayers: 15
+    # minimumPlayers: 15 - Andromeda
     weight: 1
     duration: 900
     maxDuration: 1200
@@ -219,7 +219,7 @@
     endAudio:
       path: /Audio/_NF/Announcements/PocketSizedAndy/andy2_bluespace_ship_leave.ogg
     earliestStart: 80
-    minimumPlayers: 15
+    # minimumPlayers: 15 - Andromeda
     weight: 1
     duration: 1800
     maxDuration: 2400


### PR DESCRIPTION
## Sobre o PR
Tira `minimumPlayers` do YML dos UIVs

## Porque / Balaceamento
Me doi dizer isso mas a gente raramente tem 15 players :sob: 
Remove essas entradas ate segunda ordem; Os UIVs tem conteúdo e equipamentos de alto nivel (além de serem os maiores causadores de morte, superando ate os vroids) e eu quero liberar isso pra comunidade, sem precisar ser spawnado por admins

## Detalhes técnicos
Comenta as entradas de `minimumPlayers` de cada UIV (BloodMoon - cultista, syndie, wizard tower)

## Como testar
0. Remover entrada de `earliestStart` dos prototypes afetados (pra nao ter que esperar 1h20min pra aparecer um)
1. Iniciar um round
2. Esperar alguns minutos
3. Se tudo estiver certo, um UIV deve spawnar


## Requisitos (nao vou traduzir isso tudo desculpa)
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X I have added media to this PR or it does not require an ingame showcase.
- [ ] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl: tweak: UIVs agora nao tem mínimo de players para aparecerem